### PR TITLE
Matt/setup fixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,5 +6,5 @@
   <component name="NodePackageJsonFileManager">
     <packageJsonPaths />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="Python 3.7 (program-world)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="Python 3.7 (gpk-code)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/program-world.iml
+++ b/.idea/program-world.iml
@@ -10,14 +10,13 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/py/basic" isTestSource="false" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.7 (program-world)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.7 (gpk-code)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PackageRequirementsSettings">
     <option name="requirementsPath" value="" />
   </component>
   <component name="TestRunnerService">
-    <option name="projectConfiguration" value="pytest" />
     <option name="PROJECT_TEST_RUNNER" value="pytest" />
   </component>
 </module>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,9 @@ Settings:
 * Node interpreter: project
 * Mocha package: Set this to src/ts/custom-mocha, under this project root
 * User interface: tdd
+* Working Directory: set to the project root on disk
 * Extra mocha options: --srcDir=src/ts --tscOutDir=src/ts/build/tsc --preRun=script/tsc_build.sh
+* Before Launch: run external tool at script/tsc_builddir.sh
 
 
 ## Local dev server

--- a/script/init_py.sh
+++ b/script/init_py.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
-PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 bin_dir=$(dirname $0)/../bin
 

--- a/script/init_ts.sh
+++ b/script/init_ts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 this_dir=$(dirname $0)
-PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 bin_dir=$(dirname $0)/../bin
 
@@ -27,7 +27,7 @@ ln -sf /usr/local/bin/npm $bin_dir/npm
 
 # in the build, the cache is keyed on a hash of package-lock.json
 if [ ! -d "$this_dir/../src/ts/node_modules" -o $(uname) = "Darwin" ]; then
-    PATH="/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
+    PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$($this_dir/../bin/realpath $this_dir/../bin)"
     cd $this_dir/../src/ts
     time ../../bin/npm install
 fi

--- a/script/tsc_builddir.sh
+++ b/script/tsc_builddir.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+this_dir=$(dirname $0)
+mkdir -p $this_dir/../src/ts/build/tsc


### PR DESCRIPTION
@sconover to replicate the reason for the before launch script, run rm -rf src/ts/build. Then try and run in intellij. There has to be a better way to initialize build out directories outside of intellij, maybe the solution is to edit the custom mocha wrapper to create the output dir if it is not there.