### PR TITLE
Run the python module loaded in the editor by clicking the run button

### DIFF
--- a/script/download_pyodide_local.sh
+++ b/script/download_pyodide_local.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+mkdir -p ~/.pyodide-local
+cd ~/.pyodide-local
+curl -O https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js
+curl -O https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.asm.wasm
+curl -O https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.asm.data.js
+curl -O https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.asm.data
+curl -O https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.asm.js
+curl -O https://pyodide-cdn2.iodide.io/v0.15.0/full/packages.json

--- a/script/launch_local_server.sh
+++ b/script/launch_local_server.sh
@@ -6,4 +6,4 @@ PATH="$($this_dir/../bin/realpath $this_dir/../bin):/usr/bin:/bin:/usr/sbin:/sbi
 test -d $this_dir/../src/ts/build/upload
 test -f $this_dir/../src/ts/node_modules/.bin/live-server
 
-$this_dir/../src/ts/node_modules/.bin/live-server $this_dir/../src/ts/build/upload
+$this_dir/../src/ts/node_modules/.bin/live-server --mount=/pyodide-local:$HOME/.pyodide-local $this_dir/../src/ts/build/upload

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -3,7 +3,8 @@
     <script>
         window.start = new Date().getTime()
     </script>
-    <script src=" https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
+    <script src="https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
+    <!--<script src="/pyodide-local/pyodide.js"></script>-->
     <script src="./bundle.js"></script>
     <script>main()</script>
 </head>

--- a/src/ts/app/domain/src/model.ts
+++ b/src/ts/app/domain/src/model.ts
@@ -19,3 +19,7 @@ export enum PythonInterpreterStatus {
 export interface LocationHash {
     dev: string[]
 }
+
+export interface PythonExecutionEnvironment {
+    runSingleModule: (pythonModule: PythonModule) => Promise<void>
+}

--- a/src/ts/app/editor/src/action.ts
+++ b/src/ts/app/editor/src/action.ts
@@ -1,0 +1,3 @@
+import {programRunAction} from "app/program-run"
+
+export type DispatchedAction = programRunAction.KickoffRun

--- a/src/ts/app/editor/src/render-in-place.ts
+++ b/src/ts/app/editor/src/render-in-place.ts
@@ -3,6 +3,8 @@ import {Subtree} from "./subtree"
 import {renderCodeEditorInPlace} from "./render-code-editor-in-place"
 import {html} from "lit-html"
 import {renderRunButton} from "./render-run-button"
+import {Dispatch} from "redux"
+import {DispatchedAction} from "./action"
 
 interface RenderInPlaceResult {
     codeEditorResult: any
@@ -11,6 +13,7 @@ interface RenderInPlaceResult {
 
 
 export function renderInPlace(subtree: Subtree,
+                              dispatch: Dispatch<DispatchedAction>,
                               domContext: ShadowRootContext,
                               lastResult: RenderInPlaceResult): RenderInPlaceResult {
 
@@ -33,7 +36,9 @@ export function renderInPlace(subtree: Subtree,
         codeEditorShadowRootContext = domContext.initShadowRootContext(".code-editor", CssScope.CODE_EDITOR)
     }
 
-    domContext.render(renderRunButton(subtree.userCanStartCodeRun), ".header")
+    domContext.render(
+        renderRunButton(subtree.userCanStartCodeRun, subtree.nextContent.document, dispatch),
+        ".header")
 
     return {
         codeEditorResult:

--- a/src/ts/app/editor/src/render-run-button.ts
+++ b/src/ts/app/editor/src/render-run-button.ts
@@ -1,6 +1,26 @@
 import {html, TemplateResult} from "lit-html"
+import {Dispatch} from "redux"
+import {DispatchedAction} from "./action"
+import {programRunAction} from "app/program-run"
+import {model} from "app/domain"
 
 
-export function renderRunButton(userCanStartCodeRun: boolean): TemplateResult {
-    return html`<button class="run-button" ?disabled="${(!userCanStartCodeRun)}">Run</button>`
+export function renderRunButton(userCanStartCodeRun: boolean,
+                                currentPythonModule: model.PythonModule,
+                                dispatch: Dispatch<DispatchedAction>): TemplateResult {
+
+    function dispatchKickoffRun() {
+        if (userCanStartCodeRun) {
+            dispatch({
+                type: programRunAction.Keys.KICKOFF_RUN,
+                pythonModule: currentPythonModule
+            })
+        }
+    }
+
+    return html`
+        <button 
+            class="run-button" 
+            ?disabled="${(!userCanStartCodeRun)}"
+            @click="${dispatchKickoffRun}">Run</button>`
 }

--- a/src/ts/app/editor/src/subscribe.ts
+++ b/src/ts/app/editor/src/subscribe.ts
@@ -10,7 +10,7 @@ export function subscribe(createSubtreeSubscription: CreateSubscriptionFunction<
 
     createSubtreeSubscription(
         (subtree: Subtree, dispatch: Dispatch, domContext: ShadowRootContext) => {
-            lastResult = renderInPlace(subtree, domContext, lastResult)
+            lastResult = renderInPlace(subtree, dispatch, domContext, lastResult)
         },
         domContext)
 

--- a/src/ts/app/framework/src/improved-loop.ts
+++ b/src/ts/app/framework/src/improved-loop.ts
@@ -2,7 +2,11 @@ import {Action} from "redux"
 
 export type ImprovedLoopReducer<S, HandledA extends Action, DispatchedA extends Action> = (previous: S, action: HandledA) => S | [S, DispatchedA]
 
-export type PromiseFuncDefinition<A, R, F extends (...args: any[]) => Promise<R>> = [F, Parameters<F>, (result: R) => A]
+export interface PromiseFuncDefinition<A, R, F extends (...args: any[]) => Promise<R>> {
+    func: F,
+    args: Parameters<F>,
+    successActionCreator: (result: R) => A
+}
 
 export type ImprovedCommand = Action | PromiseFuncDefinition<any, any, any>
 
@@ -16,7 +20,7 @@ export type ImprovedLoopAction<S, A extends Action> = (state: S, nextAction: A) 
 // note: because this type forces usage of generics at the callsite,
 // the compiler won't narrow the action type (which is always a union),
 // because of this TS limitation.
-// That means that when composing the actions returned by the successAppActionCreator,
+// That means that when composing the actions returned by the successActionCreator,
 // you can't rely on the compiler to do excess parameter checking, etc.
 /**
  * Given
@@ -28,9 +32,7 @@ export type ImprovedLoopAction<S, A extends Action> = (state: S, nextAction: A) 
  */
 export type ImprovedLoopPromiseFunc = <S, A extends Action, R, F extends (...args: any[]) => Promise<R>>(
     state: S,
-    f: F,
-    args: Parameters<F>,
-    successAppActionCreator: (result: R) => A) => [S, A]
+    funcDef: PromiseFuncDefinition<A, R, F>) => [S, A]
 
 export type ImprovedLoopList = <S, A extends Action>(
     state: S,

--- a/src/ts/app/framework/src/redux-loop-improved-loop.ts
+++ b/src/ts/app/framework/src/redux-loop-improved-loop.ts
@@ -4,17 +4,20 @@ import {
     ImprovedLoop,
     ImprovedLoopAction,
     ImprovedLoopCombineReducers,
-    ImprovedLoopPromiseFunc
+    ImprovedLoopPromiseFunc,
+    PromiseFuncDefinition
 } from "./improved-loop"
 import {flatten} from "lib/util"
 
 
 export const reduxLoopBasedList: ImprovedLoopAction<any, any> = (state, ...commands: (ImprovedCommand | ImprovedCommand[])[]) => {
     return loop(state, Cmd.list(flatten(commands).map((c) => {
-        if ((<any>c).type && (<any>c).type == "RUN") {
-            return makeCmdRun.apply(c)
-        } else {
+        if (c.func) {
+            return makeCmdRun2(c)
+        } else if (c.type) {
             return makeAction(c)
+        } else {
+            throw new Error(`Don't know what to do with ${c}`)
         }
     })))
 }
@@ -31,21 +34,25 @@ export const reduxLoopBasedAction: ImprovedLoopAction<any, any> = (state, nextAc
 function makeCmdRun<A, R, F extends (...args: any[]) => Promise<R>>(
     f: F,
     args: Parameters<F>,
-    successAppActionCreator: (result: R) => A) {
+    successActionCreator: (result: R) => A) {
     return Cmd.run(f, {
         args: args,
-        successActionCreator: (<any>successAppActionCreator)
+        successActionCreator: (<any>successActionCreator)
+    })
+}
+
+function makeCmdRun2<A, R, F extends (...args: any[]) => Promise<R>>(pf: PromiseFuncDefinition<A, R, F>) {
+    return Cmd.run(pf.func, {
+        args: pf.args,
+        successActionCreator: (<any>pf.successActionCreator)
     })
 }
 
 export const reduxLoopBasedPromiseFunc: ImprovedLoopPromiseFunc =
     <S, A, R, F extends (...args: any[]) => Promise<R>>(
         state: S,
-        f: F,
-        args: Parameters<F>,
-        successAppActionCreator: (result: R) => A): [S, A] => {
-        return ((<any>loop(state,
-            makeCmdRun(f, args, successAppActionCreator))))
+        pf: PromiseFuncDefinition<A, R, F>): [S, A] => {
+        return ((<any>loop(state, makeCmdRun2(pf))))
     }
 
 export const reduxLoopBasedCombineReducers: ImprovedLoopCombineReducers = (reducers: any) =>

--- a/src/ts/app/page/src/reducer.ts
+++ b/src/ts/app/page/src/reducer.ts
@@ -4,18 +4,24 @@ import * as stateTransition from "./state-transition"
 import {checkExhaustiveAndReturn} from "lib/util"
 import {pageAction} from "./action"
 
-type HandledAction = pageAction.ChangeDevInLocationHash
+type HandledAction =
+    pageAction.Init |
+    pageAction.ChangeDevInLocationHash
 
 export function createReducer(): ImprovedLoopReducer<Subtree, HandledAction, any> {
     return function reduce(previous: Subtree, action: HandledAction): Subtree | [Subtree, any] {
         switch (action.type) {
+
+            case pageAction.Keys.INIT:
+                console.log(action.type)
+                return previous
 
             case pageAction.Keys.CHANGE_DEV_IN_LOCATION_HASH:
                 return stateTransition.locationHashDevChanged(previous, action.dev)
 
         }
 
-        return checkExhaustiveAndReturn(action.type, previous)
+        return checkExhaustiveAndReturn(action, previous)
     }
 }
 

--- a/src/ts/app/program-run/src/action.ts
+++ b/src/ts/app/program-run/src/action.ts
@@ -6,6 +6,8 @@ export namespace programRunAction {
         INTERPRETER_STATUS_CHANGED = "programRun/INTERPRETER_STATUS_CHANGED",
         WRITE_TO_STDOUT = "programRun/WRITE_TO_STDOUT",
         WRITE_TO_STDERR = "programRun/WRITE_TO_STDERR",
+        KICKOFF_RUN = "programRun/KICKOFF_RUN",
+        RUN_FINISHED = "programRun/RUN_FINISHED",
     }
 
     export interface InterpreterStatusChanged extends Action<Keys> {
@@ -22,4 +24,15 @@ export namespace programRunAction {
         type: Keys.WRITE_TO_STDERR
         text: string
     }
+
+    export interface KickoffRun extends Action<Keys> {
+        type: Keys.KICKOFF_RUN
+        pythonModule: model.PythonModule // TODO: array of modules, with name of the one to run
+    }
+
+    export interface RunFinished extends Action<Keys> {
+        type: Keys.RUN_FINISHED
+    }
 }
+
+export type DispatchedAction = programRunAction.InterpreterStatusChanged

--- a/src/ts/app/program-run/src/index.ts
+++ b/src/ts/app/program-run/src/index.ts
@@ -1,1 +1,4 @@
 export {programRunAction} from "./action"
+export {Subtree} from "./subtree"
+export {initSubtree} from "./state-transition"
+export {createReducer} from "./reducer"

--- a/src/ts/app/program-run/src/reducer.ts
+++ b/src/ts/app/program-run/src/reducer.ts
@@ -1,0 +1,48 @@
+import {ImprovedLoop, ImprovedLoopReducer} from "app/framework"
+import {Subtree} from "./subtree"
+import {checkExhaustiveAndReturn} from "lib/util"
+import {model} from "app/domain"
+import {DispatchedAction, programRunAction} from "./action"
+
+type HandledAction =
+    programRunAction.KickoffRun |
+    programRunAction.RunFinished
+
+export interface ReducerInputs {
+    improvedLoop: ImprovedLoop<Subtree, HandledAction, any>,
+    python: model.PythonExecutionEnvironment
+}
+
+export function createReducer(inputs: ReducerInputs): ImprovedLoopReducer<Subtree, HandledAction, DispatchedAction> {
+    return function reduce(previous: Subtree, action: HandledAction): Subtree | [Subtree, DispatchedAction] {
+        switch (action.type) {
+            case programRunAction.Keys.KICKOFF_RUN:
+                return inputs.improvedLoop.list(
+                    previous,
+                    {
+                        type: programRunAction.Keys.INTERPRETER_STATUS_CHANGED,
+                        newStatus: model.PythonInterpreterStatus.RUNNING
+                    } as programRunAction.InterpreterStatusChanged,
+                    {
+                        func: inputs.python.runSingleModule.bind(inputs.python),
+                        args: [action.pythonModule],
+                        successActionCreator: () => {
+                            return {
+                                type: programRunAction.Keys.RUN_FINISHED
+                            }
+                        }
+                    }
+                )
+
+            case programRunAction.Keys.RUN_FINISHED:
+                return inputs.improvedLoop.action(previous, {
+                    type: programRunAction.Keys.INTERPRETER_STATUS_CHANGED,
+                    newStatus: model.PythonInterpreterStatus.READY_TO_RUN
+                })
+        }
+
+        return checkExhaustiveAndReturn(action, previous)
+    }
+}
+
+

--- a/src/ts/app/program-run/src/state-transition.ts
+++ b/src/ts/app/program-run/src/state-transition.ts
@@ -1,0 +1,5 @@
+import {Subtree} from "./subtree"
+
+export function initSubtree(): Subtree {
+    return {}
+}

--- a/src/ts/app/program-run/src/subtree.ts
+++ b/src/ts/app/program-run/src/subtree.ts
@@ -1,0 +1,2 @@
+export interface Subtree {
+}

--- a/src/ts/app/program-run/test/python-execution-environment-for-testing.ts
+++ b/src/ts/app/program-run/test/python-execution-environment-for-testing.ts
@@ -1,0 +1,15 @@
+import {model} from "app/domain"
+import {SynchronousPromise} from "synchronous-promise"
+
+export class PythonExecutionEnvironmentForTesting implements model.PythonExecutionEnvironment {
+    constructor(public didRun: model.PythonModule[] = []) {
+    }
+
+    runSingleModule(pythonModule: model.PythonModule): Promise<void> {
+        this.didRun.push(pythonModule)
+
+        return new SynchronousPromise((resolve) => {
+            resolve()
+        })
+    }
+}

--- a/src/ts/app/program-run/test/reducer-KICKOFF_RUN-test.ts
+++ b/src/ts/app/program-run/test/reducer-KICKOFF_RUN-test.ts
@@ -1,0 +1,47 @@
+import {assert} from "chai"
+import {suite, test} from "mocha"
+import {createReducer} from "../src/reducer"
+import {ImprovedLoopForTesting} from "app/framework/test-support"
+import * as stateTransition from "../src/state-transition"
+import {Subtree} from "../src/subtree"
+import {PythonExecutionEnvironmentForTesting} from "./python-execution-environment-for-testing"
+import {programRunAction} from "app/program-run"
+import {model} from "app/domain"
+
+suite("program-run reducer - KICKOFF_RUN", () => {
+    const testLoop = new ImprovedLoopForTesting()
+    const testPython = new PythonExecutionEnvironmentForTesting()
+
+    const simpleReducer = createReducer({
+        improvedLoop: testLoop,
+        python: testPython
+    })
+
+    test("run a python module", () => {
+        const nextState =
+            simpleReducer(
+                stateTransition.initSubtree(), {
+                    type: programRunAction.Keys.KICKOFF_RUN,
+                    pythonModule: {
+                        name: "foo",
+                        content: `print("hello")`
+                    }
+                }) as Subtree
+
+        assert.deepEqual(testLoop.simulateRun(), [
+            {
+                type: programRunAction.Keys.INTERPRETER_STATUS_CHANGED,
+                newStatus: model.PythonInterpreterStatus.RUNNING
+            } as programRunAction.InterpreterStatusChanged,
+            {
+                type: programRunAction.Keys.RUN_FINISHED
+            } as programRunAction.RunFinished
+        ])
+
+        assert.deepEqual(testPython.didRun, [{
+            name: "foo",
+            content: `print("hello")`
+        }])
+    })
+})
+

--- a/src/ts/app/root/src/reducer.ts
+++ b/src/ts/app/root/src/reducer.ts
@@ -2,11 +2,14 @@ import * as ConsoleModule from "app/console"
 import * as DevModule from "app/dev"
 import * as EditorModule from "app/editor"
 import * as PageModule from "app/page"
+import * as ProgramRunModule from "app/program-run"
 import * as StorageModule from "app/storage"
 import {ImprovedLoop, ImprovedLoopReducer} from "app/framework"
+import {model} from "app/domain"
 
 interface ReducerInputs {
     improvedLoop: ImprovedLoop<any, any, any>,
+    python: model.PythonExecutionEnvironment
 }
 
 export function createReducer(inputs: ReducerInputs): ImprovedLoopReducer<any, any, any> {
@@ -21,6 +24,10 @@ export function createReducer(inputs: ReducerInputs): ImprovedLoopReducer<any, a
             improvedLoop: inputs.improvedLoop
         }),
         pageSubtree: PageModule.createReducer(),
+        programRunSubtree: ProgramRunModule.createReducer({
+            improvedLoop: inputs.improvedLoop,
+            python: inputs.python
+        }),
         storageSubtree: StorageModule.createReducer({
             improvedLoop: inputs.improvedLoop
         }),

--- a/src/ts/app/root/src/root-state.ts
+++ b/src/ts/app/root/src/root-state.ts
@@ -2,6 +2,7 @@ import * as ConsoleModule from "app/console"
 import * as DevModule from "app/dev"
 import * as EditorModule from "app/editor"
 import * as PageModule from "app/page"
+import * as ProgramRunModule from "app/program-run"
 import * as StorageModule from "app/storage"
 
 
@@ -10,5 +11,6 @@ export interface RootState {
     devSubtree: DevModule.Subtree,
     editorSubtree: EditorModule.Subtree,
     pageSubtree: PageModule.Subtree,
+    programRunSubtree: ProgramRunModule.Subtree,
     storageSubtree: StorageModule.Subtree
 }

--- a/src/ts/app/root/src/state-transition.ts
+++ b/src/ts/app/root/src/state-transition.ts
@@ -2,6 +2,7 @@ import * as ConsoleModule from "app/console"
 import * as DevModule from "app/dev"
 import * as EditorModule from "app/editor"
 import * as PageModule from "app/page"
+import * as ProgramRunModule from "app/program-run"
 import * as StorageModule from "app/storage"
 import {RootState} from "app/root"
 
@@ -11,6 +12,7 @@ export function initRootState(): RootState {
         devSubtree: DevModule.initSubtree(),
         editorSubtree: EditorModule.initSubtree(),
         pageSubtree: PageModule.initSubtree(),
+        programRunSubtree: ProgramRunModule.initSubtree(),
         storageSubtree: StorageModule.initSubtree(),
     }
 }

--- a/src/ts/lib/util/src/check.ts
+++ b/src/ts/lib/util/src/check.ts
@@ -1,6 +1,6 @@
 export function checkState(condition: boolean, errorMessage: string) {
     if (!condition) {
-        throw new Error(errorMessage)
+        throw new Error(errorMessage + "  This is an error on the part of the authors of this application.")
     }
 }
 

--- a/src/ts/main/src/install-pyodide-std-io-action-adapters.ts
+++ b/src/ts/main/src/install-pyodide-std-io-action-adapters.ts
@@ -1,7 +1,7 @@
 import {programRunAction} from "app/program-run"
 import {Dispatch} from "redux"
 
-export function installPyodideStdoutputActionAdapters(
+export function installPyodideStdIoActionAdapters(
     window: any,
     pyodide: any,
     dispatch: Dispatch<programRunAction.WriteToStdout | programRunAction.WriteToStderr>) {

--- a/src/ts/main/src/main.ts
+++ b/src/ts/main/src/main.ts
@@ -5,18 +5,14 @@ import * as RootModule from "app/root"
 import {InvokeSubscriptionFunction} from "../../app/framework/src/subscriber"
 import {Action, createStore, Store} from "redux"
 import {install, StoreCreator} from "redux-loop"
-import {programRunAction} from "app/program-run"
-import {model} from "app/domain"
 import {pageAction} from "app/page"
-import {installPyodideStdoutputActionAdapters} from "./install-pyodide-stdoutput-action-adapters"
 import {installCtlShiftKeyComboActionAdapter} from "./install-ctl-shift-key-combo-action-adapter"
 import {installDragDropActionAdapaters} from "./install-drag-drop-action-adapters"
 import {installEscapeKeyActionAdapter} from "./install-escape-key-action-adapter"
 import {parseLocationHash} from "./parse-location-hash"
 import {setLocationHash} from "./set-location-hash"
-
-declare const languagePluginLoader: Promise<any>
-declare const pyodide: any
+import {pyodideInit} from "./pyodide-init"
+import {SwappablePythonExecutionEnvironment} from "./swappable-python-execution-environment"
 
 function main() {
     const start = (<any>window).start
@@ -27,11 +23,14 @@ function main() {
 
     document.addEventListener("DOMContentLoaded", function () {
 
+        const swappablePython = new SwappablePythonExecutionEnvironment(undefined)
+
         const enhancedCreateStore = createStore as StoreCreator
         const store: Store<RootModule.RootState, Action> =
             enhancedCreateStore(
                 RootModule.createReducer({
                     improvedLoop: reduxLoopBasedImprovedLoop,
+                    python: swappablePython
                 }),
                 RootModule.initRootState(),
                 install())
@@ -57,61 +56,9 @@ function main() {
         installEscapeKeyActionAdapter(document, store.dispatch)
         installDragDropActionAdapaters(document, store.dispatch)
 
-        // for more about languagePluginLoader, see https://github.com/iodide-project/pyodide/blob/master/src/pyodide.js
-        languagePluginLoader.then(() => {
-
-            installPyodideStdoutputActionAdapters(window, pyodide, store.dispatch)
-
-            const pathsCreated: { [key: string]: boolean } = {}
-            pyodide._module.FS.mkdir("/py")
-
-            for (let relativePath in PROJECT_PYTHON_FILES) {
-                const relativeDirectory = relativePath.substring(0, relativePath.lastIndexOf("/"))
-
-                const parts = relativeDirectory.split("/")
-
-                let dir = "/py"
-                parts.forEach((part) => {
-                    dir = dir + "/" + part
-                    if (!pathsCreated[dir]) {
-                        pyodide._module.FS.mkdir(dir)
-                        pathsCreated[dir] = true
-                    }
-                })
-
-                pyodide._module.FS.writeFile("/py/" + relativePath, PROJECT_PYTHON_FILES[relativePath])
-            }
-
-
-            pyodide.runPython("print('hello world, from Python')")
-            pyodide.runPython(`import sys; sys.stderr.write("stderr this time - hello world, from Python\\n")`)
-
-            console.log(new Date().getTime() - start)
-
-
-            pyodide.runPython(`
-            import ast
-            print(ast.parse("print('hello world, from Python AST')"))
-
-            import sys
-            print("Python version")
-            print (sys.version)
-            print("Version info.")
-            print (sys.version_info)
-
-            # make use of a function that comes from python code loaded is from the surrounding project
-            sys.path.append("/py/basic")
-            from append import append
-            print(append("appended hello ", "world"))
-            `)
-
-            console.log(new Date().getTime() - start)
-
-            store.dispatch({
-                type: programRunAction.Keys.INTERPRETER_STATUS_CHANGED,
-                newStatus: model.PythonInterpreterStatus.READY_TO_RUN
-            })
-        })
+        pyodideInit(start, store, (python => {
+            swappablePython.actualPython = python
+        }))
     })
 }
 

--- a/src/ts/main/src/pyodide-init.ts
+++ b/src/ts/main/src/pyodide-init.ts
@@ -1,0 +1,68 @@
+import {Action, Store} from "redux"
+import * as RootModule from "app/root"
+import {installPyodideStdIoActionAdapters} from "./install-pyodide-std-io-action-adapters"
+import {PROJECT_PYTHON_FILES} from "./managed-by-build"
+import {programRunAction} from "app/program-run"
+import {model} from "app/domain"
+import {writeFile} from "./pyodide-util"
+import {PyodidePythonExecutionEnvironment} from "./pyodide-python-execution-environment"
+
+declare const languagePluginLoader: Promise<any>
+declare const pyodide: any
+
+
+export function pyodideInit(start: number,
+                            store: Store<RootModule.RootState, Action>,
+                            onReadyCallback: (pythonEnv: model.PythonExecutionEnvironment) => void) {
+
+    // for more about languagePluginLoader, see https://github.com/iodide-project/pyodide/blob/master/src/pyodide.js
+    languagePluginLoader.then(() => {
+
+        installPyodideStdIoActionAdapters(window, pyodide, store.dispatch)
+
+        for (let relativePath in PROJECT_PYTHON_FILES) {
+            writeFile(pyodide._module.FS, "/.lib/" + relativePath, PROJECT_PYTHON_FILES[relativePath])
+        }
+
+        pyodide.runPython("print('hello world, from Python')")
+        pyodide.runPython(`import sys; sys.stderr.write("stderr this time - hello world, from Python\\n")`)
+
+        console.log(new Date().getTime() - start)
+
+        pyodide.runPython(`
+        
+        import ast
+        print(ast.parse("print('hello world, from Python AST')"))
+        
+        import sys
+        print("Python version")
+        print (sys.version)
+        print("Version info.")
+        print (sys.version_info)
+        
+        # make use of a function that comes from python code loaded is from the surrounding project
+        sys.path.append("/.lib/basic")
+        from append import append
+        print(append("appended hello ", "world"))
+        
+        `)
+
+        const python = new PyodidePythonExecutionEnvironment(pyodide)
+
+        python.runSingleModule({
+            name: "test_module",
+            content: `print("from the test module")`
+        })
+
+        console.log(new Date().getTime() - start)
+
+        console.log("pyodide ready")
+
+        onReadyCallback(python)
+
+        store.dispatch({
+            type: programRunAction.Keys.INTERPRETER_STATUS_CHANGED,
+            newStatus: model.PythonInterpreterStatus.READY_TO_RUN
+        })
+    })
+}

--- a/src/ts/main/src/pyodide-python-execution-environment.ts
+++ b/src/ts/main/src/pyodide-python-execution-environment.ts
@@ -1,0 +1,21 @@
+import {model} from "app/domain"
+import {writeFile} from "./pyodide-util"
+
+export class PyodidePythonExecutionEnvironment implements model.PythonExecutionEnvironment {
+    constructor(private pyodide: any,
+                private runCounter: number = 0) {}
+
+    runSingleModule(pythonModule: model.PythonModule) {
+        this.runCounter += 1
+        const runTimestamp = new Date().toISOString()
+
+        const srcDirForRun = `/run/${this.runCounter}`
+        const modulePath = `${srcDirForRun}/${pythonModule.name}.py`
+
+        writeFile(this.pyodide._module.FS, modulePath, pythonModule.content)
+        return this.pyodide.runPythonAsync(`
+            import runpy
+            runpy.run_path("${modulePath}")
+        `)
+    }
+}

--- a/src/ts/main/src/pyodide-util.ts
+++ b/src/ts/main/src/pyodide-util.ts
@@ -1,0 +1,7 @@
+export function writeFile(emscriptenFs: any, path: string, content: string) {
+    const dir = path.substring(0, path.lastIndexOf("/"))
+    if (!emscriptenFs.findObject(dir)) {
+        emscriptenFs.mkdirTree(dir)
+    }
+    emscriptenFs.writeFile(path, content)
+}

--- a/src/ts/main/src/swappable-python-execution-environment.ts
+++ b/src/ts/main/src/swappable-python-execution-environment.ts
@@ -1,0 +1,16 @@
+import {model} from "app/domain"
+import {checkState} from "lib/util"
+
+export class SwappablePythonExecutionEnvironment implements model.PythonExecutionEnvironment {
+
+    constructor(public actualPython?: model.PythonExecutionEnvironment) {
+    }
+
+    runSingleModule(pythonModule: model.PythonModule) {
+        checkState(this.actualPython != null,
+            "run called when python env not initialized")
+
+        return this.actualPython!.runSingleModule(pythonModule)
+    }
+
+}

--- a/src/ts/package-lock.json
+++ b/src/ts/package-lock.json
@@ -6851,6 +6851,12 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
+    "synchronous-promise": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.13.tgz",
+      "integrity": "sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA==",
+      "dev": true
+    },
     "tar": {
       "version": "4.4.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",

--- a/src/ts/package.json
+++ b/src/ts/package.json
@@ -33,6 +33,7 @@
     "mocha": "7.2.0",
     "@types/mocha": "7.0.2",
     "tsconfig-paths": "3.9.0",
-    "@types/emscripten": "1.39.4"
+    "@types/emscripten": "1.39.4",
+    "synchronous-promise": "2.0.13"
   }
 }


### PR DESCRIPTION
- Extract and cleanup pyodide initialization
- On run, write the python module from the editor "to disk" in
  the pyodide interpreter, and run it using runpy.run_file
- Adjustments to improved-loop promiseFunc, so they actually work,
  and work well with improved-loop list
- Some support for "offline" pyodide dev

local pyodide support
extract init pyodide function
simplified mkdir
working py module execute example
run python code from editor via pyodide execution environment
correct improved loop / promise func. run button disabled during code run.
program run test - kickoff