### PR TITLE
Switch among multiple py modules in the editor, also run any of them

### DIFF
--- a/script/upload-to-gcs.js
+++ b/script/upload-to-gcs.js
@@ -1,6 +1,6 @@
-const assert = require('assert')
-const fs = require('fs')
-const path = require('path')
+const assert = require("assert")
+const fs = require("fs")
+const path = require("path")
 
 const args = process.argv.slice(2)
 assert.equal(args.length, 1)
@@ -11,17 +11,17 @@ assert.ok(fs.lstatSync(baseDir).isDirectory())
 const filesToUpload = []
 
 function recursivelyFindFiles(dir) {
-  fs.readdirSync(dir).forEach(file => {
-    let fullPath = path.join(dir, file)
-    const lstat = fs.lstatSync(fullPath)
-    assert.ok(lstat.size < 5_000_000, "sanity-check file size")
+    fs.readdirSync(dir).forEach(file => {
+        let fullPath = path.join(dir, file)
+        const lstat = fs.lstatSync(fullPath)
+        assert.ok(lstat.size < 5_000_000, "sanity-check file size")
 
-    if (lstat.isDirectory()) {
-      recursivelyFindFiles(fullPath)
-    } else {
-      filesToUpload.push(fullPath)
-    }
-  })
+        if (lstat.isDirectory()) {
+            recursivelyFindFiles(fullPath)
+        } else {
+            filesToUpload.push(fullPath)
+        }
+    })
 }
 
 recursivelyFindFiles(baseDir)
@@ -30,12 +30,17 @@ console.log("files to upload: ", filesToUpload)
 assert.ok(filesToUpload.length < 20, "sanity-check file count")
 
 
-const {Storage} = require('@google-cloud/storage');
-const storage = new Storage();
-const bucket = storage.bucket('dev.gpkpw.com');
+const {Storage} = require("@google-cloud/storage")
+const storage = new Storage()
+const bucket = storage.bucket("dev.gpkpw.com")
 
 filesToUpload.forEach((localFilePath) => {
-  const destPath = localFilePath.substring(baseDir.length + 1)
-  bucket.upload(localFilePath, {destination: destPath})
-  console.log(`uploaded '${localFilePath}' to '${destPath}'`)
+    const destPath = localFilePath.substring(baseDir.length + 1)
+    bucket.upload(localFilePath, {
+        destination: destPath,
+        metadata: {
+            cacheControl: "no-cache, max-age=0",
+        },
+    })
+    console.log(`uploaded '${localFilePath}' to '${destPath}'`)
 })

--- a/src/ts/app/dev/src/action.ts
+++ b/src/ts/app/dev/src/action.ts
@@ -5,10 +5,15 @@ import {pageAction} from "app/page"
 export namespace localAction {
     export enum Keys {
         DROP_FILE_HELLO = "dev/DROP_FILE_HELLO",
+        DROP_FILES_PREFIXING = "dev/DROP_FILES_PREFIXING",
     }
 
     export interface DropFileFooHello extends Action<Keys> {
         type: Keys.DROP_FILE_HELLO
+    }
+
+    export interface DropFilesPrefixing extends Action<Keys> {
+        type: Keys.DROP_FILES_PREFIXING
     }
 }
 
@@ -16,4 +21,5 @@ export namespace localAction {
 export type DispatchedAction =
     storageAction.ReceiveDroppedFile |
     localAction.DropFileFooHello |
+    localAction.DropFilesPrefixing |
     pageAction.ChangeDevInLocationHash

--- a/src/ts/app/dev/src/reducer.ts
+++ b/src/ts/app/dev/src/reducer.ts
@@ -10,7 +10,8 @@ type HandledAction =
     pageAction.Init |
     pageAction.MetaKeyComboPressed |
     pageAction.EscapeKeyPressed |
-    localAction.DropFileFooHello
+    localAction.DropFileFooHello |
+    localAction.DropFilesPrefixing
 
 export interface ReducerInputs {
     improvedLoop: ImprovedLoop<Subtree, HandledAction, DispatchedAction>
@@ -70,6 +71,43 @@ export function createReducer(inputs: ReducerInputs): ImprovedLoopReducer<Subtre
                     {
                         type: pageAction.Keys.CHANGE_DEV_IN_LOCATION_HASH,
                         dev: nextState.accumulatedActions
+                    } as pageAction.ChangeDevInLocationHash)
+
+            case localAction.Keys.DROP_FILES_PREFIXING:
+                const nextStatePrefixing = stateTransition.withAccumulatedDevAction(previous, action)
+
+                return inputs.improvedLoop.list(
+                    nextStatePrefixing,
+                    {
+                        type: storageAction.Keys.RECEIVE_DROPPED_FILE,
+                        name: "try",
+                        content: [
+                            "from prefix1 import prefix_foo",
+                            "from prefix2 import prefix_bar",
+                            "",
+                            "print(prefix_foo('first try'))",
+                            "print(prefix_bar('second try'))"
+                        ].join("\n") + "\n"
+                    } as storageAction.ReceiveDroppedFile,
+                    {
+                        type: storageAction.Keys.RECEIVE_DROPPED_FILE,
+                        name: "prefix1",
+                        content: [
+                            "def prefix_foo(str):",
+                            "    return 'foo: ' + str"
+                        ].join("\n") + "\n"
+                    } as storageAction.ReceiveDroppedFile,
+                    {
+                        type: storageAction.Keys.RECEIVE_DROPPED_FILE,
+                        name: "prefix2",
+                        content: [
+                            "def prefix_bar(str):",
+                            "    return 'bar: ' + str"
+                        ].join("\n") + "\n"
+                    } as storageAction.ReceiveDroppedFile,
+                    {
+                        type: pageAction.Keys.CHANGE_DEV_IN_LOCATION_HASH,
+                        dev: nextStatePrefixing.accumulatedActions
                     } as pageAction.ChangeDevInLocationHash)
 
             default:

--- a/src/ts/app/dev/src/render.ts
+++ b/src/ts/app/dev/src/render.ts
@@ -20,7 +20,11 @@ export function render(open: boolean, dispatch: Dispatch<DispatchedAction>): Tem
             
             <div class="frame">
                 <button @click="${() => dispatch({type: localAction.Keys.DROP_FILE_HELLO})}">
-                    file drop: foo.py/hello
+                    drop file: foo.py/hello
+                </button>
+                
+                <button @click="${() => dispatch({type: localAction.Keys.DROP_FILES_PREFIXING})}">
+                    drop files: try.py,prefix1.py,prefix2.py
                 </button>
             </div>
         `

--- a/src/ts/app/domain/src/model.ts
+++ b/src/ts/app/domain/src/model.ts
@@ -6,8 +6,8 @@ export interface PythonModule {
 }
 
 export interface DocumentCollection {
-    documents: model.PythonModule[]
-    nameToDocument: { [key: string]: model.PythonModule }
+    pythonModules: model.PythonModule[]
+    nameToPythonModule: { [key: string]: model.PythonModule }
 }
 
 export enum PythonInterpreterStatus {
@@ -21,5 +21,5 @@ export interface LocationHash {
 }
 
 export interface PythonExecutionEnvironment {
-    runSingleModule: (pythonModule: PythonModule) => Promise<void>
+    runModules: (pythonModules: PythonModule[], indexOfModuleToRun: number) => Promise<void>
 }

--- a/src/ts/app/editor/src/action.ts
+++ b/src/ts/app/editor/src/action.ts
@@ -1,3 +1,17 @@
+import {Action} from "redux"
 import {programRunAction} from "app/program-run"
 
-export type DispatchedAction = programRunAction.KickoffRun
+export namespace localAction {
+    export enum Keys {
+        CHANGE_PYTHON_MODULE_IN_EDITOR = "editor/CHANGE_PYTHON_MODULE_IN_EDITOR"
+    }
+
+    export interface ChangePythonModuleInEditor extends Action<Keys> {
+        type: Keys.CHANGE_PYTHON_MODULE_IN_EDITOR
+        pythonModuleIndex: number
+    }
+}
+
+export type DispatchedAction =
+    programRunAction.KickoffRun |
+    localAction.ChangePythonModuleInEditor

--- a/src/ts/app/editor/src/reducer.ts
+++ b/src/ts/app/editor/src/reducer.ts
@@ -4,10 +4,13 @@ import {Subtree} from "./subtree"
 import * as stateTransition from "./state-transition"
 import {checkExhaustiveAndReturn} from "lib/util"
 import {programRunAction} from "app/program-run"
+import {localAction} from "./action"
+
 
 type HandledAction =
     storageAction.AddedPythonModule |
-    programRunAction.InterpreterStatusChanged
+    programRunAction.InterpreterStatusChanged |
+    localAction.ChangePythonModuleInEditor
 
 export interface ReducerInputs {
     improvedLoop: ImprovedLoop<Subtree, HandledAction, any>
@@ -18,10 +21,12 @@ export function createReducer(inputs: ReducerInputs): ImprovedLoopReducer<Subtre
         const previous = stateTransition.bumpUpdateCounter(_previous)
 
         switch (action.type) {
+
+            case localAction.Keys.CHANGE_PYTHON_MODULE_IN_EDITOR:
+                return stateTransition.setNextEditorContentToPythonModuleIndex(previous, action.pythonModuleIndex)
+
             case storageAction.Keys.ADDED_PYTHON_MODULE:
-                return stateTransition.setNextEditorContent(
-                    previous,
-                    action.documentCollection.documents[action.documentCollection.documents.length - 1])
+                return stateTransition.setNextEditorContent(previous, action.documentCollection)
 
             case programRunAction.Keys.INTERPRETER_STATUS_CHANGED:
                 return stateTransition.updateForInterpreterStatusChange(previous, action.newStatus)

--- a/src/ts/app/editor/src/render-code-editor-in-place.ts
+++ b/src/ts/app/editor/src/render-code-editor-in-place.ts
@@ -35,7 +35,8 @@ export function renderCodeEditorInPlace(subtree: Subtree,
     }
 
     if (subtree.nextContent.setOnCounter == subtree.updateCounter) {
-        result.editor!.getDoc().setValue(subtree.nextContent.document.content)
+        result.editor!.getDoc()
+            .setValue(subtree.documentCollection.pythonModules[subtree.nextContent.pythonModuleIndex].content)
     }
 
     return result

--- a/src/ts/app/editor/src/render-in-place.ts
+++ b/src/ts/app/editor/src/render-in-place.ts
@@ -5,6 +5,7 @@ import {html} from "lit-html"
 import {renderRunButton} from "./render-run-button"
 import {Dispatch} from "redux"
 import {DispatchedAction} from "./action"
+import {renderPythonModuleSelectDropdownBox} from "./render-python-module-select-dropdown-box"
 
 interface RenderInPlaceResult {
     codeEditorResult: any
@@ -25,9 +26,15 @@ export function renderInPlace(subtree: Subtree,
         domContext.render(
             html`
             <style>
+                .header {
+                    display: flex;
+                }
             </style>
             <div>
-                <div class="header"></div>
+                <div class="header">
+                    <div class="module-select"></div>
+                    <div class="run"></div>
+                </div>
                 <div class="code-editor"></div>
             </div>
             
@@ -37,8 +44,19 @@ export function renderInPlace(subtree: Subtree,
     }
 
     domContext.render(
-        renderRunButton(subtree.userCanStartCodeRun, subtree.nextContent.document, dispatch),
-        ".header")
+        renderRunButton(
+            subtree.userCanStartCodeRun,
+            subtree.documentCollection.pythonModules,
+            subtree.nextContent.pythonModuleIndex,
+            dispatch),
+        ".run")
+
+    domContext.render(
+        renderPythonModuleSelectDropdownBox(
+            subtree.documentCollection.pythonModules,
+            subtree.nextContent.pythonModuleIndex,
+            dispatch),
+        ".module-select")
 
     return {
         codeEditorResult:

--- a/src/ts/app/editor/src/render-python-module-select-dropdown-box.ts
+++ b/src/ts/app/editor/src/render-python-module-select-dropdown-box.ts
@@ -1,0 +1,23 @@
+import {html, TemplateResult} from "lit-html"
+import {model} from "app/domain"
+import {DispatchedAction, localAction} from "./action"
+import {Dispatch} from "redux"
+
+export function renderPythonModuleSelectDropdownBox(pythonModules: model.PythonModule[],
+                                                    selectedModuleIndex: number,
+                                                    dispatch: Dispatch<DispatchedAction>): TemplateResult {
+
+    function dispatchChangeSelectedModule(event: any) {
+        dispatch({
+            type: localAction.Keys.CHANGE_PYTHON_MODULE_IN_EDITOR,
+            pythonModuleIndex: parseInt(event.target.value)
+        })
+    }
+
+    return html`
+        <select @change="${dispatchChangeSelectedModule}">
+            ${pythonModules.map((m, i) =>
+        html`<option value="${i}" ?selected="${i == selectedModuleIndex}">${m.name}</option>`)}
+        </select>
+    `
+}

--- a/src/ts/app/editor/src/render-run-button.ts
+++ b/src/ts/app/editor/src/render-run-button.ts
@@ -6,14 +6,16 @@ import {model} from "app/domain"
 
 
 export function renderRunButton(userCanStartCodeRun: boolean,
-                                currentPythonModule: model.PythonModule,
+                                currentPythonModules: model.PythonModule[],
+                                currentPythonModuleIndex: number,
                                 dispatch: Dispatch<DispatchedAction>): TemplateResult {
 
     function dispatchKickoffRun() {
         if (userCanStartCodeRun) {
             dispatch({
                 type: programRunAction.Keys.KICKOFF_RUN,
-                pythonModule: currentPythonModule
+                pythonModules: currentPythonModules,
+                indexOfModuleToRun: currentPythonModuleIndex
             })
         }
     }

--- a/src/ts/app/editor/src/state-transition.ts
+++ b/src/ts/app/editor/src/state-transition.ts
@@ -7,10 +7,11 @@ export function initSubtree(): Subtree {
     return {
         nextContent: {
             setOnCounter: 0,
-            document: {
-                name: "new",
-                content: ""
-            }
+            pythonModuleIndex: -1
+        },
+        documentCollection: {
+            pythonModules: [],
+            nameToPythonModule: {}
         },
         updateCounter: 0,
         userCanStartCodeRun: false
@@ -23,11 +24,21 @@ export function bumpUpdateCounter(previous: Subtree): Subtree {
     })
 }
 
-export function setNextEditorContent(previous: Subtree, document: model.PythonModule): Subtree {
+export function setNextEditorContent(previous: Subtree, documentCollection: model.DocumentCollection): Subtree {
     return produce(previous, draft => {
         draft.nextContent = {
             setOnCounter: previous.updateCounter,
-            document: document
+            pythonModuleIndex: documentCollection.pythonModules.length - 1
+        }
+        draft.documentCollection = documentCollection
+    })
+}
+
+export function setNextEditorContentToPythonModuleIndex(previous: Subtree, i: number): Subtree {
+    return produce(previous, draft => {
+        draft.nextContent = {
+            setOnCounter: previous.updateCounter,
+            pythonModuleIndex: i
         }
     })
 }

--- a/src/ts/app/editor/src/subtree.ts
+++ b/src/ts/app/editor/src/subtree.ts
@@ -2,11 +2,13 @@ import {model} from "app/domain"
 
 interface NextContent {
     setOnCounter: number
-    document: model.PythonModule
+    pythonModuleIndex: number
 }
 
 export interface Subtree {
     updateCounter: number
     nextContent: NextContent
     userCanStartCodeRun: boolean
+
+    documentCollection: model.DocumentCollection
 }

--- a/src/ts/app/editor/test/reducer-ADDED_PYTHON_MODULE-test.ts
+++ b/src/ts/app/editor/test/reducer-ADDED_PYTHON_MODULE-test.ts
@@ -5,6 +5,7 @@ import {ImprovedLoopForTesting} from "app/framework/test-support"
 import * as stateTransition from "../src/state-transition"
 import {storageAction} from "app/storage"
 import {Subtree} from "../src/subtree"
+import {model} from "app/domain"
 
 suite("editor reducer - ADDED_PYTHON_MODULE", () => {
     const testLoop = new ImprovedLoopForTesting()
@@ -15,14 +16,14 @@ suite("editor reducer - ADDED_PYTHON_MODULE", () => {
         })
 
     test("python module added", () => {
-        const incomingDocumentCollection = {
-            documents: [
+        const incomingDocumentCollection: model.DocumentCollection = {
+            pythonModules: [
                 {
                     name: "foo",
                     content: "print('hello')"
                 }
             ],
-            nameToDocument: {
+            nameToPythonModule: {
                 "foo": {
                     name: "foo",
                     content: "print('hello')"
@@ -40,10 +41,7 @@ suite("editor reducer - ADDED_PYTHON_MODULE", () => {
         assert.equal(nextState.updateCounter, 1)
         assert.deepEqual(nextState.nextContent, {
             setOnCounter: 1,
-            document: {
-                name: "foo",
-                content: "print('hello')"
-            }
+            pythonModuleIndex: 0
         })
     })
 })

--- a/src/ts/app/editor/test/reducer-CHANGE_PYTHON_MODULE_IN_EDITOR-test.ts
+++ b/src/ts/app/editor/test/reducer-CHANGE_PYTHON_MODULE_IN_EDITOR-test.ts
@@ -1,0 +1,40 @@
+import {assert} from "chai"
+import {suite, test} from "mocha"
+import {createReducer} from "../src/reducer"
+import * as stateTransition from "../src/state-transition"
+import {Subtree} from "../src/subtree"
+import {ImprovedLoopForTesting} from "app/framework/test-support"
+import {localAction} from "../src/action"
+
+
+suite("editor reducer - CHANGE_PYTHON_MODULE_IN_EDITOR", () => {
+    const testLoop = new ImprovedLoopForTesting()
+
+    const simpleReducer =
+        createReducer({
+            improvedLoop: testLoop
+        })
+
+    test("basics", () => {
+        const nextState =
+            simpleReducer(
+                stateTransition.setNextEditorContent(
+                    stateTransition.initSubtree(),
+                    {
+                        pythonModules: [{
+                            name: "foo",
+                            content: `print("hello")`
+                        }, {
+                            name: "bar",
+                            content: `print("world")`
+                        }],
+                        nameToPythonModule: {}
+                    }), {
+                    type: localAction.Keys.CHANGE_PYTHON_MODULE_IN_EDITOR,
+                    pythonModuleIndex: 1
+                }) as Subtree
+
+        assert.equal(nextState.nextContent.pythonModuleIndex, 1)
+    })
+})
+

--- a/src/ts/app/program-run/src/action.ts
+++ b/src/ts/app/program-run/src/action.ts
@@ -27,7 +27,8 @@ export namespace programRunAction {
 
     export interface KickoffRun extends Action<Keys> {
         type: Keys.KICKOFF_RUN
-        pythonModule: model.PythonModule // TODO: array of modules, with name of the one to run
+        pythonModules: model.PythonModule[]
+        indexOfModuleToRun: number
     }
 
     export interface RunFinished extends Action<Keys> {

--- a/src/ts/app/program-run/src/reducer.ts
+++ b/src/ts/app/program-run/src/reducer.ts
@@ -24,8 +24,11 @@ export function createReducer(inputs: ReducerInputs): ImprovedLoopReducer<Subtre
                         newStatus: model.PythonInterpreterStatus.RUNNING
                     } as programRunAction.InterpreterStatusChanged,
                     {
-                        func: inputs.python.runSingleModule.bind(inputs.python),
-                        args: [action.pythonModule],
+                        func: inputs.python.runModules.bind(inputs.python),
+                        args: [
+                            action.pythonModules,
+                            action.indexOfModuleToRun
+                        ],
                         successActionCreator: () => {
                             return {
                                 type: programRunAction.Keys.RUN_FINISHED

--- a/src/ts/app/program-run/test/python-execution-environment-for-testing.ts
+++ b/src/ts/app/program-run/test/python-execution-environment-for-testing.ts
@@ -2,14 +2,18 @@ import {model} from "app/domain"
 import {SynchronousPromise} from "synchronous-promise"
 
 export class PythonExecutionEnvironmentForTesting implements model.PythonExecutionEnvironment {
-    constructor(public didRun: model.PythonModule[] = []) {
+    constructor(public didWrite: model.PythonModule[][] = [],
+                public didRun: model.PythonModule[] = []) {
     }
 
-    runSingleModule(pythonModule: model.PythonModule): Promise<void> {
-        this.didRun.push(pythonModule)
+    runModules(pythonModules: model.PythonModule[], indexOfModuleToRun: number): Promise<void> {
+        this.didWrite.push(pythonModules)
+        this.didRun.push(pythonModules[indexOfModuleToRun])
 
         return new SynchronousPromise((resolve) => {
             resolve()
         })
     }
+
+
 }

--- a/src/ts/app/program-run/test/reducer-KICKOFF_RUN-test.ts
+++ b/src/ts/app/program-run/test/reducer-KICKOFF_RUN-test.ts
@@ -22,10 +22,14 @@ suite("program-run reducer - KICKOFF_RUN", () => {
             simpleReducer(
                 stateTransition.initSubtree(), {
                     type: programRunAction.Keys.KICKOFF_RUN,
-                    pythonModule: {
+                    pythonModules: [{
                         name: "foo",
                         content: `print("hello")`
-                    }
+                    }, {
+                        name: "bar",
+                        content: `print("world")`
+                    }],
+                    indexOfModuleToRun: 1
                 }) as Subtree
 
         assert.deepEqual(testLoop.simulateRun(), [
@@ -38,9 +42,17 @@ suite("program-run reducer - KICKOFF_RUN", () => {
             } as programRunAction.RunFinished
         ])
 
-        assert.deepEqual(testPython.didRun, [{
+        assert.deepEqual(testPython.didWrite, [[{
             name: "foo",
             content: `print("hello")`
+        }, {
+            name: "bar",
+            content: `print("world")`
+        }]])
+
+        assert.deepEqual(testPython.didRun, [{
+            name: "bar",
+            content: `print("world")`
         }])
     })
 })

--- a/src/ts/app/storage/src/state-transition.ts
+++ b/src/ts/app/storage/src/state-transition.ts
@@ -4,8 +4,8 @@ import produce from "immer"
 export function initSubtree(): Subtree {
     return {
         documentCollection: {
-            documents: [],
-            nameToDocument: {}
+            pythonModules: [],
+            nameToPythonModule: {}
         },
 
         lastDocumentChangeIndexApplied: 0,
@@ -31,28 +31,28 @@ export function applyNextFileChanges(previous: Subtree) {
             switch (fileChange.type) {
                 case(FileChangeType.ADD_PYTHON_MODULE):
 
-                    if (draft.documentCollection.nameToDocument[fileChange.name]?.content === fileChange.content) {
+                    if (draft.documentCollection.nameToPythonModule[fileChange.name]?.content === fileChange.content) {
                         break
                     }
 
                     let assignedName = fileChange.name
-                    if (draft.documentCollection.nameToDocument[assignedName]) {
+                    if (draft.documentCollection.nameToPythonModule[assignedName]) {
                         let i = 1
-                        while (draft.documentCollection.nameToDocument[assignedName]) {
+                        while (draft.documentCollection.nameToPythonModule[assignedName]) {
                             i += 1
                             assignedName = `${fileChange.name}_${i}`
                         }
                     }
 
-                    draft.documentCollection.documents.push({
+                    draft.documentCollection.pythonModules.push({
                         name: assignedName,
                         content: fileChange.content
                     })
             }
 
-            draft.documentCollection.nameToDocument = {}
-            draft.documentCollection.documents
-                .forEach((d) => draft.documentCollection.nameToDocument[d.name] = d)
+            draft.documentCollection.nameToPythonModule = {}
+            draft.documentCollection.pythonModules
+                .forEach((d) => draft.documentCollection.nameToPythonModule[d.name] = d)
         })
     })
 }

--- a/src/ts/app/storage/src/subtree.ts
+++ b/src/ts/app/storage/src/subtree.ts
@@ -1,5 +1,4 @@
-import {DocumentCollection} from "../../domain/src/model"
-
+import {model} from "app/domain"
 
 export enum FileChangeType {
     ADD_PYTHON_MODULE = "ADD_PYTHON_MODULE"
@@ -15,5 +14,5 @@ export interface Subtree {
     documentChanges: (AddPythonModule)[]
     lastDocumentChangeIndexApplied: number
 
-    documentCollection: DocumentCollection
+    documentCollection: model.DocumentCollection
 }

--- a/src/ts/app/storage/test/reducer-RECEIVE_DROPPED_FILE-test.ts
+++ b/src/ts/app/storage/test/reducer-RECEIVE_DROPPED_FILE-test.ts
@@ -5,6 +5,7 @@ import {DispatchedAction, storageAction} from "../src/action"
 import {Subtree} from "../src/subtree"
 import {ImprovedLoopForTesting} from "app/framework/test-support"
 import * as stateTransition from "../src/state-transition"
+import {model} from "app/domain"
 
 suite("storage reducer - RECEIVE_DROPPED_FILE", () => {
     const testLoop = new ImprovedLoopForTesting<DispatchedAction>()
@@ -23,14 +24,14 @@ suite("storage reducer - RECEIVE_DROPPED_FILE", () => {
                     content: "print('hello')"
                 }) as [Subtree, any]
 
-        const expectedDocumentCollection = {
-            documents: [
+        const expectedDocumentCollection: model.DocumentCollection = {
+            pythonModules: [
                 {
                     name: "foo",
                     content: "print('hello')"
                 }
             ],
-            nameToDocument: {
+            nameToPythonModule: {
                 "foo": {
                     name: "foo",
                     content: "print('hello')"

--- a/src/ts/app/storage/test/state-transition-applyNextFileChanges-test.ts
+++ b/src/ts/app/storage/test/state-transition-applyNextFileChanges-test.ts
@@ -15,10 +15,10 @@ suite("storage state transition - applyNextFileChanges", () => {
         const nextState = stateTransition.applyNextFileChanges(initialState)
 
         assert.deepEqual(nextState.documentCollection, {
-            documents: [
+            pythonModules: [
                 {name: "foo", content: "print('hello')"}
             ],
-            nameToDocument: {
+            nameToPythonModule: {
                 "foo": {name: "foo", content: "print('hello')"}
             }
         })
@@ -40,10 +40,10 @@ suite("storage state transition - applyNextFileChanges", () => {
         const nextState = stateTransition.applyNextFileChanges(initialState)
 
         assert.deepEqual(nextState.documentCollection, {
-            documents: [
+            pythonModules: [
                 {name: "foo", content: "print('hello')"}
             ],
-            nameToDocument: {
+            nameToPythonModule: {
                 "foo": {name: "foo", content: "print('hello')"}
             }
         })
@@ -70,12 +70,12 @@ suite("storage state transition - applyNextFileChanges", () => {
         const nextState = stateTransition.applyNextFileChanges(initialState)
 
         assert.deepEqual(nextState.documentCollection, {
-            documents: [
+            pythonModules: [
                 {name: "foo", content: "print('hello')"},
                 {name: "foo_2", content: "print('world')"},
                 {name: "foo_3", content: "print('zz')"}
             ],
-            nameToDocument: {
+            nameToPythonModule: {
                 "foo": {name: "foo", content: "print('hello')"},
                 "foo_2": {name: "foo_2", content: "print('world')"},
                 "foo_3": {name: "foo_3", content: "print('zz')"}

--- a/src/ts/main/src/pyodide-init.ts
+++ b/src/ts/main/src/pyodide-init.ts
@@ -49,10 +49,10 @@ export function pyodideInit(start: number,
 
         const python = new PyodidePythonExecutionEnvironment(pyodide)
 
-        python.runSingleModule({
+        python.runModules([{
             name: "test_module",
             content: `print("from the test module")`
-        })
+        }], 0)
 
         console.log(new Date().getTime() - start)
 

--- a/src/ts/main/src/swappable-python-execution-environment.ts
+++ b/src/ts/main/src/swappable-python-execution-environment.ts
@@ -6,11 +6,10 @@ export class SwappablePythonExecutionEnvironment implements model.PythonExecutio
     constructor(public actualPython?: model.PythonExecutionEnvironment) {
     }
 
-    runSingleModule(pythonModule: model.PythonModule) {
+    runModules(pythonModules: model.PythonModule[], indexOfModuleToRun: number): Promise<void> {
         checkState(this.actualPython != null,
             "run called when python env not initialized")
 
-        return this.actualPython!.runSingleModule(pythonModule)
+        return this.actualPython!.runModules(pythonModules, indexOfModuleToRun)
     }
-
 }


### PR DESCRIPTION
- Rudimentary ability to select among many python modules loaded
  into the editor
- The run function causes the currently-viewed code to execute
- All modules are loaded on to the pyodide filesystem
- Simple imports across python modules work
- Fix for gcs static-website file caching for dev site (no caching)

rename documents to python modules
dev scenario - drop multiple py files
select python module from dropdown to switch the current module
run one among a group of modules (the module selected in the editor).
  so, write all python modules to the pyodide filesystem,
  ensure that the run path is in the sys path,
  and then execute the module seen by the user
use public pyodide
don't cache branch depoy files
adjust tests for multiple python modules